### PR TITLE
fix(cli): importing config command in wrong name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const args = require('./cli');
-const {example: exampleCmd, commands: configCmd} = require('./commands/');
+const {example: exampleCmd, config: configCmd} = require('./commands/');
 
 const start = async () => {
     if(args.e) {


### PR DESCRIPTION
crash when passing config

Closes #13